### PR TITLE
  Added functionality to validate Paysera Delivery API credentials (project_id and password) for use during initial setup or configuration changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Then, implement all necessary interfaces:
 - [Integration with SDK](docs/BEFORE_USING.md)
 
 ## Use cases
+- [Validating credentials](docs/VALIDATING_CREDENTIALS.md)
 - [Delivery orders creating](docs/DELIVERY_ORDER_CREATING.md)
 - [Delivery orders updating](docs/DELIVERY_ORDER_UPDATING.md)
 - [Callbacks handling](docs/HANDLING_CALLBACKS_FROM_API.md)

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "paysera/lib-delivery-api-merchant-client": "^1.2",
+        "paysera/lib-delivery-api-merchant-client": "^1.5",
         "psr/container": "^2.0",
         "webtopay/libwebtopay": "^3.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d9caed69a9575b77a1a546e3213f3eea",
+    "content-hash": "9e280e905711636a02b67ee4bf68e0cf",
     "packages": [
         {
             "name": "evp/money",
@@ -101,22 +101,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.9.3",
+            "version": "7.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77"
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
-                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5.3 || ^2.0.3",
-                "guzzlehttp/psr7": "^2.7.0",
+                "guzzlehttp/promises": "^2.3",
+                "guzzlehttp/psr7": "^2.8",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -207,7 +207,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.9.3"
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
             },
             "funding": [
                 {
@@ -223,20 +223,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T13:37:11+00:00"
+            "time": "2025-08-23T22:36:01+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c"
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/7c69f28996b0a6920945dd20b3857e499d9ca96c",
-                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
                 "shasum": ""
             },
             "require": {
@@ -244,7 +244,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "type": "library",
             "extra": {
@@ -290,7 +290,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.2.0"
+                "source": "https://github.com/guzzle/promises/tree/2.3.0"
             },
             "funding": [
                 {
@@ -306,20 +306,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T13:27:01+00:00"
+            "time": "2025-08-22T14:34:08+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.7.1",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
+                "reference": "21dc724a0583619cd1652f673303492272778051"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
-                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
+                "reference": "21dc724a0583619cd1652f673303492272778051",
                 "shasum": ""
             },
             "require": {
@@ -335,7 +335,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -406,7 +406,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.7.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
             },
             "funding": [
                 {
@@ -422,7 +422,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T12:30:47+00:00"
+            "time": "2025-08-23T21:21:41+00:00"
         },
         {
             "name": "maba/math",
@@ -536,16 +536,16 @@
         },
         {
             "name": "paysera/lib-delivery-api-merchant-client",
-            "version": "1.2.1",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paysera/lib-delivery-api-merchant-client.git",
-                "reference": "263496744b42f1fb10767636fba05efea743a783"
+                "reference": "2943b121f7037ce5743c909f456936de3edd03a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paysera/lib-delivery-api-merchant-client/zipball/263496744b42f1fb10767636fba05efea743a783",
-                "reference": "263496744b42f1fb10767636fba05efea743a783",
+                "url": "https://api.github.com/repos/paysera/lib-delivery-api-merchant-client/zipball/2943b121f7037ce5743c909f456936de3edd03a8",
+                "reference": "2943b121f7037ce5743c909f456936de3edd03a8",
                 "shasum": ""
             },
             "require": {
@@ -564,22 +564,22 @@
             "description": "Paysera Delivery Api Merchant Client",
             "support": {
                 "issues": "https://github.com/paysera/lib-delivery-api-merchant-client/issues",
-                "source": "https://github.com/paysera/lib-delivery-api-merchant-client/tree/1.2.1"
+                "source": "https://github.com/paysera/lib-delivery-api-merchant-client/tree/1.5.1"
             },
-            "time": "2025-04-29T10:04:12+00:00"
+            "time": "2025-12-03T12:45:08+00:00"
         },
         {
             "name": "paysera/lib-rest-client-common",
-            "version": "2.7.1",
+            "version": "2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paysera/lib-rest-client-common.git",
-                "reference": "57b581abba953ed8ac956035c1e937d0e9cef3ea"
+                "reference": "7698353254fa73d16415e1c0ef98ea0af3c4b6c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paysera/lib-rest-client-common/zipball/57b581abba953ed8ac956035c1e937d0e9cef3ea",
-                "reference": "57b581abba953ed8ac956035c1e937d0e9cef3ea",
+                "url": "https://api.github.com/repos/paysera/lib-rest-client-common/zipball/7698353254fa73d16415e1c0ef98ea0af3c4b6c8",
+                "reference": "7698353254fa73d16415e1c0ef98ea0af3c4b6c8",
                 "shasum": ""
             },
             "require": {
@@ -603,9 +603,9 @@
             "description": "Base classes/helpers used in REST Clients",
             "support": {
                 "issues": "https://github.com/paysera/lib-rest-client-common/issues",
-                "source": "https://github.com/paysera/lib-rest-client-common/tree/2.7.1"
+                "source": "https://github.com/paysera/lib-rest-client-common/tree/2.7.2"
             },
-            "time": "2025-03-17T09:53:44+00:00"
+            "time": "2025-07-23T13:14:38+00:00"
         },
         {
             "name": "psr/container",
@@ -933,16 +933,16 @@
         },
         {
             "name": "webtopay/libwebtopay",
-            "version": "3.1.1",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paysera/lib-webtopay.git",
-                "reference": "950e8149839815ffc5dca6384cdea0bc3d12de79"
+                "reference": "2e70d938097cee5ef817362416865b0e80a77ce0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paysera/lib-webtopay/zipball/950e8149839815ffc5dca6384cdea0bc3d12de79",
-                "reference": "950e8149839815ffc5dca6384cdea0bc3d12de79",
+                "url": "https://api.github.com/repos/paysera/lib-webtopay/zipball/2e70d938097cee5ef817362416865b0e80a77ce0",
+                "reference": "2e70d938097cee5ef817362416865b0e80a77ce0",
                 "shasum": ""
             },
             "require": {
@@ -982,9 +982,9 @@
             "description": "PHP Library for Paysera payment gateway integration",
             "support": {
                 "issues": "https://github.com/paysera/lib-webtopay/issues",
-                "source": "https://github.com/paysera/lib-webtopay/tree/3.1.1"
+                "source": "https://github.com/paysera/lib-webtopay/tree/3.1.5"
             },
-            "time": "2025-01-21T08:16:44+00:00"
+            "time": "2025-08-05T11:28:10+00:00"
         }
     ],
     "packages-dev": [
@@ -1061,16 +1061,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.4.3",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
                 "shasum": ""
             },
             "require": {
@@ -1122,7 +1122,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.3"
+                "source": "https://github.com/composer/semver/tree/3.4.4"
             },
             "funding": [
                 {
@@ -1132,13 +1132,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T14:15:21+00:00"
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -1280,6 +1276,7 @@
                 "issues": "https://github.com/doctrine/annotations/issues",
                 "source": "https://github.com/doctrine/annotations/tree/1.14.4"
             },
+            "abandoned": true,
             "time": "2024-09-05T10:15:52+00:00"
         },
         {
@@ -1569,20 +1566,20 @@
         },
         {
             "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.1",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3|^7.0|^8.0"
+                "php": "^7.4|^8.0"
             },
             "replace": {
                 "cordoval/hamcrest-php": "*",
@@ -1590,8 +1587,8 @@
                 "kodova/hamcrest-php": "*"
             },
             "require-dev": {
-                "phpunit/php-file-iterator": "^1.4 || ^2.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -1614,9 +1611,9 @@
             ],
             "support": {
                 "issues": "https://github.com/hamcrest/hamcrest-php/issues",
-                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
-            "time": "2020-07-09T08:09:16+00:00"
+            "time": "2025-04-30T06:54:44+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -1703,16 +1700,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.0",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -1751,7 +1748,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -1759,20 +1756,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-12T12:17:51+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.4.0",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
@@ -1791,7 +1788,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -1815,9 +1812,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2024-12-30T11:07:19+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2040,16 +2037,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.23",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "29201e7a743a6ab36f91394eab51889a82631428"
-            },
+            "version": "1.12.32",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/29201e7a743a6ab36f91394eab51889a82631428",
-                "reference": "29201e7a743a6ab36f91394eab51889a82631428",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2770dcdf5078d0b0d53f94317e06affe88419aa8",
+                "reference": "2770dcdf5078d0b0d53f94317e06affe88419aa8",
                 "shasum": ""
             },
             "require": {
@@ -2094,7 +2086,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-23T14:57:32+00:00"
+            "time": "2025-09-30T10:16:31+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -2566,16 +2558,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.22",
+            "version": "9.6.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c"
+                "reference": "945d0b7f346a084ce5549e95289962972c4272e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
-                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/945d0b7f346a084ce5549e95289962972c4272e5",
+                "reference": "945d0b7f346a084ce5549e95289962972c4272e5",
                 "shasum": ""
             },
             "require": {
@@ -2586,7 +2578,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.1",
+                "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
@@ -2597,11 +2589,11 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.8",
+                "sebastian/comparator": "^4.0.9",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.6",
-                "sebastian/global-state": "^5.0.7",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
                 "sebastian/object-enumerator": "^4.0.4",
                 "sebastian/resource-operations": "^3.0.4",
                 "sebastian/type": "^3.2.1",
@@ -2649,7 +2641,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.22"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.31"
             },
             "funding": [
                 {
@@ -2661,11 +2653,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-05T13:48:26+00:00"
+            "time": "2025-12-06T07:45:52+00:00"
         },
         {
             "name": "psr/cache",
@@ -2985,16 +2985,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "4.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
                 "shasum": ""
             },
             "require": {
@@ -3047,15 +3047,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2025-08-10T06:51:50+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -3245,16 +3257,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.6",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
                 "shasum": ""
             },
             "require": {
@@ -3310,28 +3322,40 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:33:00+00:00"
+            "time": "2025-09-24T06:03:27+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
@@ -3374,15 +3398,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -3555,16 +3591,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
@@ -3606,15 +3642,27 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -4240,7 +4288,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -4299,7 +4347,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4311,6 +4359,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -4319,16 +4371,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe"
+                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
-                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
                 "shasum": ""
             },
             "require": {
@@ -4377,7 +4429,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4389,15 +4441,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2025-06-27T09:58:17+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -4458,7 +4514,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4470,6 +4526,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -4478,7 +4538,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -4539,7 +4599,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4548,6 +4608,10 @@
                 },
                 {
                     "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
                     "type": "github"
                 },
                 {
@@ -4624,7 +4688,7 @@
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -4680,7 +4744,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4692,6 +4756,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -4700,7 +4768,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -4760,7 +4828,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4772,6 +4840,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -4780,7 +4852,7 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.32.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -4836,7 +4908,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4845,6 +4917,10 @@
                 },
                 {
                     "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
                     "type": "github"
                 },
                 {
@@ -4918,16 +4994,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.0",
+            "version": "v3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
                 "shasum": ""
             },
             "require": {
@@ -4981,7 +5057,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
             },
             "funding": [
                 {
@@ -4993,11 +5069,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-25T09:37:31+00:00"
+            "time": "2025-07-15T11:30:57+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -5063,16 +5143,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.24",
+            "version": "v6.4.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f0ce0bd36a3accb4a225435be077b4b4875587f4"
+                "reference": "50590a057841fa6bf69d12eceffce3465b9e32cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f0ce0bd36a3accb4a225435be077b4b4875587f4",
-                "reference": "f0ce0bd36a3accb4a225435be077b4b4875587f4",
+                "url": "https://api.github.com/repos/symfony/string/zipball/50590a057841fa6bf69d12eceffce3465b9e32cb",
+                "reference": "50590a057841fa6bf69d12eceffce3465b9e32cb",
                 "shasum": ""
             },
             "require": {
@@ -5086,7 +5166,6 @@
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/error-handler": "^5.4|^6.0|^7.0",
                 "symfony/http-client": "^5.4|^6.0|^7.0",
                 "symfony/intl": "^6.2|^7.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
@@ -5129,7 +5208,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.24"
+                "source": "https://github.com/symfony/string/tree/v6.4.30"
             },
             "funding": [
                 {
@@ -5149,20 +5228,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T08:14:14+00:00"
+            "time": "2025-11-21T18:03:05+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -5191,7 +5270,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -5199,11 +5278,11 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:36:25+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/docs/BEFORE_USING.md
+++ b/docs/BEFORE_USING.md
@@ -18,6 +18,7 @@ This SDK provides tools for working with the Paysera Delivery API. To ensure the
 6. [MerchantOrderLoggerInterface.php](../src/Service/MerchantOrderLoggerInterface.php) - A logger for info messages related to your (merchant) order processing
 
 ## And after implementing necessary interfaces, go to use cases
-- [Delivery orders creating](docs/DELIVERY_ORDER_CREATING.md)
-- [Delivery orders updating](docs/DELIVERY_ORDER_UPDATING.md)
-- [Callbacks handling](docs/HANDLING_CALLBACKS_FROM_API.md)
+- [Validating credentials](VALIDATING_CREDENTIALS.md)
+- [Delivery orders creating](DELIVERY_ORDER_CREATING.md)
+- [Delivery orders updating](DELIVERY_ORDER_UPDATING.md)
+- [Callbacks handling](HANDLING_CALLBACKS_FROM_API.md)

--- a/docs/VALIDATING_CREDENTIALS.md
+++ b/docs/VALIDATING_CREDENTIALS.md
@@ -1,0 +1,324 @@
+# Validating Credentials
+
+This guide describes how to validate Paysera Delivery API credentials (project ID and password) during initial setup or configuration.
+
+## Overview
+
+The credentials validation feature allows you to verify if the provided `project_id` and `password` are valid. This is useful for:
+
+- Validating user input in configuration forms
+- Troubleshooting authentication issues
+- Implementing setup wizards with credential verification
+
+## How it works
+
+The validation uses a public (unauthenticated) API endpoint `/rest/v1/projects/validate-credentials` that:
+- Returns **HTTP 204** (No Content) if credentials are valid
+- Returns **HTTP 401** (Unauthorized) if credentials are invalid
+- Returns **HTTP 429** (Too Many Requests) if rate limit is exceeded
+
+## Usage
+
+### Basic Example
+
+```php
+use Paysera\DeliveryApi\MerchantClient\Entity\ProjectCredentials;
+use Paysera\DeliverySdk\Exception\CredentialsValidationException;
+use Paysera\DeliverySdk\Exception\RateLimitExceededException;
+use Paysera\DeliverySdk\Exception\MerchantClientNotFoundException;
+
+// Create credentials object
+$credentials = new ProjectCredentials([
+    'project_id' => '123456',  // Note: must be a string
+    'password' => 'your-api-password'
+]);
+
+// Validate credentials
+try {
+    $isValid = $deliveryFacade->validateCredentials($credentials);
+
+    if ($isValid) {
+        echo "Credentials are valid!";
+    } else {
+        echo "Credentials are invalid!";
+    }
+} catch (RateLimitExceededException $exception) {
+    // Handle rate limit (HTTP 429)
+    echo "Too many validation attempts. Please try again later.";
+} catch (MerchantClientNotFoundException $exception) {
+    // Handle merchant client configuration error
+    echo "Service configuration error. Please contact support.";
+} catch (CredentialsValidationException $exception) {
+    // Handle other validation errors (HTTP 401, 403, etc.)
+    echo "Validation failed: " . $exception->getMessage();
+}
+```
+
+### Integration in Configuration Forms
+
+Example of validating credentials in a settings form:
+
+```php
+use Paysera\DeliveryApi\MerchantClient\Entity\ProjectCredentials;
+use Paysera\DeliverySdk\Exception\CredentialsValidationException;
+use Paysera\DeliverySdk\Exception\RateLimitExceededException;
+use Paysera\DeliverySdk\Exception\MerchantClientNotFoundException;
+
+// In your settings controller
+public function saveSettings(array $postData): void
+{
+    $projectId = $postData['project_id'];
+    $password = $postData['project_password'];
+
+    // Create credentials object
+    $credentials = new ProjectCredentials([
+        'project_id' => (string) $projectId,  // Must be string
+        'password' => $password
+    ]);
+
+    // Validate credentials before saving
+    try {
+        $isValid = $this->deliveryFacade->validateCredentials($credentials);
+
+        if (!$isValid) {
+            throw new InvalidArgumentException('Invalid Paysera Delivery API credentials');
+        }
+
+        // Credentials are valid, save settings
+        $this->settingsRepository->save([
+            'project_id' => $projectId,
+            'project_password' => $password,
+        ]);
+
+        $this->showSuccessMessage('Settings saved successfully!');
+
+    } catch (RateLimitExceededException $exception) {
+        // Handle rate limit (HTTP 429)
+        $this->showErrorMessage('Too many validation attempts. Please wait 5 minutes and try again.');
+        $this->logger->warning('Rate limit exceeded during credentials validation', [
+            'project_id' => $projectId,
+            'exception' => $exception
+        ]);
+    } catch (MerchantClientNotFoundException $exception) {
+        // Handle configuration error
+        $this->showErrorMessage('Service configuration error. Please contact support.');
+        $this->logger->error('Merchant client not found', ['exception' => $exception]);
+    } catch (CredentialsValidationException $exception) {
+        // Handle validation errors (invalid credentials, network issues, etc.)
+        $this->showErrorMessage('Could not validate credentials: ' . $exception->getMessage());
+        $this->logger->error('Credentials validation failed', [
+            'project_id' => $projectId,
+            'exception' => $exception
+        ]);
+    }
+}
+```
+
+### Setup Wizard Example
+
+Using validation in a multi-step setup wizard:
+
+```php
+use Paysera\DeliveryApi\MerchantClient\Entity\ProjectCredentials;
+use Paysera\DeliverySdk\Exception\CredentialsValidationException;
+use Paysera\DeliverySdk\Exception\RateLimitExceededException;
+use Paysera\DeliverySdk\Exception\MerchantClientNotFoundException;
+
+public function setupWizardStep1(): void
+{
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        $projectId = $_POST['project_id'];
+        $password = $_POST['password'];
+
+        // Create credentials object
+        $credentials = new ProjectCredentials([
+            'project_id' => (string) $projectId,
+            'password' => $password
+        ]);
+
+        try {
+            $isValid = $this->deliveryFacade->validateCredentials($credentials);
+
+            if ($isValid) {
+                // Store validated credentials in session
+                $_SESSION['delivery_credentials'] = [
+                    'project_id' => $projectId,
+                    'password' => $password,
+                    'validated_at' => time(),
+                ];
+
+                // Redirect to next step
+                header('Location: /setup/step2');
+                exit;
+            } else {
+                $this->showError('Invalid credentials. Please check and try again.');
+            }
+        } catch (RateLimitExceededException $exception) {
+            $this->showError('Too many attempts. Please wait a few minutes and try again.');
+        } catch (MerchantClientNotFoundException $exception) {
+            $this->showError('Service configuration error. Please contact support.');
+        } catch (CredentialsValidationException $exception) {
+            $this->showError('Validation error: ' . $exception->getMessage());
+        }
+    }
+
+    $this->renderForm();
+}
+```
+
+## Response Handling
+
+### Success (Valid Credentials)
+When credentials are valid, the method returns `true`:
+```php
+$credentials = new ProjectCredentials([
+    'project_id' => '123456',
+    'password' => 'your-password'
+]);
+
+$isValid = $deliveryFacade->validateCredentials($credentials);
+// $isValid === true
+```
+
+### Invalid Credentials
+When credentials are invalid, the method returns `false`:
+```php
+$isValid = $deliveryFacade->validateCredentials($credentials);
+// $isValid === false
+```
+
+### Exception Handling
+
+The method can throw three types of exceptions:
+
+#### 1. RateLimitExceededException (HTTP 429)
+Thrown when too many validation attempts are made in a short time:
+```php
+use Paysera\DeliverySdk\Exception\RateLimitExceededException;
+
+try {
+    $isValid = $deliveryFacade->validateCredentials($credentials);
+} catch (RateLimitExceededException $exception) {
+    // Rate limit exceeded - wait 5 minutes before retrying
+    echo "Too many validation attempts. Please wait and try again.";
+
+    // Get the original HTTP exception if needed
+    $httpException = $exception->getPrevious();
+    // $httpException->getResponse()->getStatusCode() === 429
+}
+```
+
+#### 2. MerchantClientNotFoundException
+Thrown when the merchant client cannot be instantiated (configuration error):
+```php
+use Paysera\DeliverySdk\Exception\MerchantClientNotFoundException;
+
+try {
+    $isValid = $deliveryFacade->validateCredentials($credentials);
+} catch (MerchantClientNotFoundException $exception) {
+    // Service configuration error - check your SDK setup
+    echo "Service configuration error. Please contact support.";
+    $this->logger->critical('Merchant client not found', ['exception' => $exception]);
+}
+```
+
+#### 3. CredentialsValidationException (HTTP 401, 403, etc.)
+Thrown for other validation errors (invalid credentials, network issues):
+```php
+use Paysera\DeliverySdk\Exception\CredentialsValidationException;
+
+try {
+    $isValid = $deliveryFacade->validateCredentials($credentials);
+} catch (CredentialsValidationException $exception) {
+    // Invalid credentials or other HTTP errors
+    echo "Validation failed: " . $exception->getMessage();
+    // Message format: "401 Unauthorized" or "403 Forbidden"
+
+    // Get the original HTTP exception
+    $httpException = $exception->getPrevious();
+}
+```
+
+### Comprehensive Error Handling
+Best practice: catch exceptions in order from most specific to most general:
+```php
+try {
+    $isValid = $deliveryFacade->validateCredentials($credentials);
+
+    if ($isValid) {
+        // Save credentials and proceed
+    } else {
+        // Should not happen - API returns HTTP 401 for invalid credentials
+        // which throws CredentialsValidationException
+    }
+} catch (RateLimitExceededException $e) {
+    // User action: wait 5 minutes
+    $this->showUserError('Too many attempts. Please try again in 5 minutes.');
+} catch (MerchantClientNotFoundException $e) {
+    // Developer action: check SDK configuration
+    $this->logger->critical('SDK configuration error', ['exception' => $e]);
+    $this->showUserError('Service unavailable. Please contact support.');
+} catch (CredentialsValidationException $e) {
+    // User action: check credentials
+    $this->showUserError('Invalid credentials: ' . $e->getMessage());
+}
+```
+
+## Important Notes
+
+1. **ProjectCredentials Type**: The method accepts `ProjectCredentials` object (not primitive types). The `project_id` field **must be a string**, not an integer:
+   ```php
+   // ✅ Correct
+   new ProjectCredentials(['project_id' => '123456', 'password' => 'pass']);
+
+   // ❌ Wrong - will cause type error
+   $deliveryFacade->validateCredentials(123456, 'pass');
+   ```
+
+2. **Usage Restrictions**: This method is intended for one-time validation during setup or configuration changes only. **Do not use it before regular operations** like creating delivery orders or fetching delivery gateways, as it will result in unnecessary API calls and may trigger rate limits.
+
+3. **Rate Limiting**: The API has rate limits. Catching `RateLimitExceededException` is important for production use. Implement exponential backoff or wait 5 minutes before retrying.
+
+4. **No Authentication Required**: This endpoint is public and doesn't require MAC authentication. The SDK handles this automatically by using a public client.
+
+5. **Logging**: All validation attempts (successful and failed) are logged at two levels:
+   - `DeliveryApiClient` - logs HTTP-level details
+   - `DeliveryOrderService` - logs operation-level details with specific messages for each exception type
+
+   Check your logs for troubleshooting. Example log messages:
+   - `"Credentials validation failed for project 123456: HTTP 429"` (rate limit)
+   - `"Operation 'validate_credentials' for project id 123456 failed due to rate limit."` (service layer)
+
+6. **Security**: Never expose credentials in client-side code or logs. Always validate credentials on the server side.
+
+## Architecture
+
+The validation flows through the following layers:
+
+1. **DeliveryFacade** - Entry point, accepts `ProjectCredentials`
+2. **DeliveryOrderService** - Business logic and comprehensive logging (logs all exception types)
+3. **DeliveryApiClient** - Exception transformation and HTTP-level logging
+4. **DeliveryOrderApiClient** - Direct API communication (passes `ProjectCredentials` to API)
+5. **MerchantClientProvider** - HTTP client creation (without authentication)
+
+Each layer adds appropriate logging and error handling. The `ProjectCredentials` object is passed through all layers without transformation until it reaches the API client.
+
+## Testing
+
+Unit tests for credential validation are located in:
+- `tests/DeliveryFacadeTest.php`
+- `tests/Service/DeliveryOrderServiceTest.php`
+- `tests/Client/DeliveryApiClientTest.php`
+- `tests/Client/DeliveryOrderApiClientTest.php`
+- `tests/Client/Provider/MerchantClientProviderTest.php`
+
+Run tests with:
+```bash
+vendor/bin/phpunit --filter validateCredentials
+```
+
+## See Also
+
+- [Integration with SDK](BEFORE_USING.md) - Setting up the SDK
+- [Delivery orders creating](DELIVERY_ORDER_CREATING.md) - Creating delivery orders
+- [Delivery orders updating](DELIVERY_ORDER_UPDATING.md) - Updating existing orders

--- a/src/Client/DeliveryOrderApiClient.php
+++ b/src/Client/DeliveryOrderApiClient.php
@@ -6,11 +6,13 @@ namespace Paysera\DeliverySdk\Client;
 
 use Paysera\DeliveryApi\MerchantClient\Entity\Order;
 use Paysera\DeliveryApi\MerchantClient\Entity\OrderIdsList;
+use Paysera\DeliveryApi\MerchantClient\Entity\ProjectCredentials;
 use Paysera\DeliverySdk\Adapter\DeliveryOrderRequestAdapterFacade;
 use Paysera\DeliverySdk\Client\Provider\MerchantClientProvider;
 use Paysera\DeliverySdk\Entity\PayseraDeliveryOrderRequest;
 use Paysera\DeliverySdk\Exception\MerchantClientNotFoundException;
 use Paysera\DeliverySdk\Exception\UndefinedDeliveryOrderException;
+use Paysera\Component\RestClientCommon\Exception\ClientException;
 
 class DeliveryOrderApiClient
 {
@@ -104,6 +106,21 @@ class DeliveryOrderApiClient
             ->getOrder(
                 (string)$deliveryOrderRequest->getOrder()->getDeliveryOrderId()
             )
+        ;
+    }
+
+    /**
+     * @param ProjectCredentials $credentials
+     * @return bool
+     * @throws MerchantClientNotFoundException
+     * @throws ClientException
+     */
+    public function validateCredentials(ProjectCredentials $credentials): bool
+    {
+        return $this
+            ->merchantClientProvider
+            ->getPublicMerchantClient()
+            ->validateProjectCredentials($credentials)
         ;
     }
 }

--- a/src/Client/Provider/MerchantClientProvider.php
+++ b/src/Client/Provider/MerchantClientProvider.php
@@ -57,6 +57,30 @@ class MerchantClientProvider
         return $merchantClient;
     }
 
+    /**
+     * @throws MerchantClientNotFoundException
+     */
+    public function getPublicMerchantClient(): MerchantClient
+    {
+        $settings = [
+            'base_url' => $this->getBaseUrl(),
+            'headers' => [
+                self::USER_AGENT_HEADER_NAME => 'Paysera-Delivery-SDK',
+            ],
+        ];
+
+        $clientFactory = new ClientFactory($settings);
+
+        try {
+            $merchantClient = $clientFactory->getMerchantClient();
+        } catch (Exception $exception) {
+            $this->logger->error('Cannot create public merchant client', $exception);
+            throw new MerchantClientNotFoundException();
+        }
+
+        return $merchantClient;
+    }
+
     private function getBaseUrl(): string
     {
         $url = getenv('DELIVERY_API_URL');

--- a/src/DeliveryFacade.php
+++ b/src/DeliveryFacade.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Paysera\DeliverySdk;
 
+use Paysera\DeliveryApi\MerchantClient\Entity\ProjectCredentials;
 use Paysera\DeliverySdk\Entity\MerchantOrderInterface;
 use Paysera\DeliverySdk\Entity\PayseraDeliveryOrderRequest;
+use Paysera\DeliverySdk\Exception\MerchantClientNotFoundException;
+use Paysera\DeliverySdk\Exception\RateLimitExceededException;
 use Paysera\DeliverySdk\Service\DeliveryOrderCallbackService;
 use Paysera\DeliverySdk\Service\DeliveryOrderService;
+use Paysera\DeliverySdk\Exception\CredentialsValidationException;
 use Paysera\DeliverySdk\Exception\DeliveryOrderRequestException;
 use Paysera\DeliverySdk\Exception\DeliveryGatewayNotFoundException;
 
@@ -61,5 +65,17 @@ class DeliveryFacade
     public function prepaidDeliveryOrder(PayseraDeliveryOrderRequest $deliveryOrderRequest): ?MerchantOrderInterface
     {
         return $this->deliveryOrderService->prepaidDeliveryOrder($deliveryOrderRequest);
+    }
+
+    /**
+     * @param ProjectCredentials $credentials
+     * @return bool
+     * @throws CredentialsValidationException
+     * @throws RateLimitExceededException
+     * @throws MerchantClientNotFoundException
+     */
+    public function validateCredentials(ProjectCredentials $credentials): bool
+    {
+        return $this->deliveryOrderService->validateCredentials($credentials);
     }
 }

--- a/src/Exception/BaseException.php
+++ b/src/Exception/BaseException.php
@@ -16,4 +16,6 @@ abstract class BaseException extends Exception
     public const E_INVALID_TYPE = 6;
     public const E_UNDEFINED_DELIVERY_GATEWAY = 7;
     public const E_UNDEFINED_DELIVERY_ORDER = 8;
+    public const E_CREDENTIALS_VALIDATION_FAILED = 9;
+    public const E_RATE_LIMIT_EXCEEDED = 10;
 }

--- a/src/Exception/CredentialsValidationException.php
+++ b/src/Exception/CredentialsValidationException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\DeliverySdk\Exception;
+
+use Throwable;
+
+class CredentialsValidationException extends BaseException
+{
+    public function __construct(string $message, Throwable $previous = null)
+    {
+        parent::__construct(
+            $message,
+            self::E_CREDENTIALS_VALIDATION_FAILED,
+            $previous
+        );
+    }
+}

--- a/src/Exception/RateLimitExceededException.php
+++ b/src/Exception/RateLimitExceededException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paysera\DeliverySdk\Exception;
+
+use Throwable;
+
+class RateLimitExceededException extends BaseException
+{
+    private const MESSAGE = 'Rate limit exceeded. Too many validation attempts.';
+    public function __construct(
+        Throwable $previous = null,
+        int $code = self::E_RATE_LIMIT_EXCEEDED
+    ) {
+        parent::__construct(self::MESSAGE, $code, $previous);
+    }
+}

--- a/tests/Client/DeliveryApiClientTest.php
+++ b/tests/Client/DeliveryApiClientTest.php
@@ -5,14 +5,21 @@ declare(strict_types=1);
 namespace Paysera\DeliverySdk\Tests\Client;
 
 use Exception;
+use Paysera\Component\RestClientCommon\Exception\ClientException;
 use Paysera\DeliveryApi\MerchantClient\Entity\Order;
+use Paysera\DeliveryApi\MerchantClient\Entity\ProjectCredentials;
 use Paysera\DeliverySdk\Client\DeliveryApiClient;
 use Paysera\DeliverySdk\Client\DeliveryOrderApiClient;
 use Paysera\DeliverySdk\Entity\MerchantOrderInterface;
 use Paysera\DeliverySdk\Entity\PayseraDeliveryOrderRequest;
+use Paysera\DeliverySdk\Exception\CredentialsValidationException;
 use Paysera\DeliverySdk\Exception\DeliveryOrderRequestException;
+use Paysera\DeliverySdk\Exception\MerchantClientNotFoundException;
+use Paysera\DeliverySdk\Exception\RateLimitExceededException;
 use Paysera\DeliverySdk\Service\DeliveryLoggerInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class DeliveryApiClientTest extends TestCase
 {
@@ -111,5 +118,147 @@ class DeliveryApiClientTest extends TestCase
         $this->expectException(DeliveryOrderRequestException::class);
 
         $this->deliveryApiClient->postOrder($this->deliveryOrderRequestMock);
+    }
+
+    public function testValidateCredentialsReturnsTrue(): void
+    {
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => '6943a905f5a1a5ebd29b4f3c4c15b818',
+        ]);
+
+        $this->orderRequestHandlerMock->expects($this->once())
+            ->method('validateCredentials')
+            ->with($this->callback(function ($arg) use ($credentials) {
+                return $arg instanceof ProjectCredentials
+                    && $arg->getProjectId() === $credentials->getProjectId()
+                    && $arg->getPassword() === $credentials->getPassword();
+            }))
+            ->willReturn(true);
+
+        $result = $this->deliveryApiClient->validateCredentials($credentials);
+
+        $this->assertTrue($result);
+    }
+
+    public function testValidateCredentialsReturnsFalse(): void
+    {
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => 'invalid_password',
+        ]);
+
+        $this->orderRequestHandlerMock->expects($this->once())
+            ->method('validateCredentials')
+            ->with($this->callback(function ($arg) use ($credentials) {
+                return $arg instanceof ProjectCredentials
+                    && $arg->getProjectId() === $credentials->getProjectId()
+                    && $arg->getPassword() === $credentials->getPassword();
+            }))
+            ->willReturn(false);
+
+        $result = $this->deliveryApiClient->validateCredentials($credentials);
+
+        $this->assertFalse($result);
+    }
+
+    public function testValidateCredentialsThrowsCredentialsValidationException(): void
+    {
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => 'invalid_password',
+        ]);
+
+        $requestMock = $this->createMock(RequestInterface::class);
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->method('getStatusCode')->willReturn(401);
+        $responseMock->method('getReasonPhrase')->willReturn('Unauthorized');
+
+        $clientException = new ClientException('Unauthorized', $requestMock, $responseMock);
+
+        $this->orderRequestHandlerMock->method('validateCredentials')
+            ->willThrowException($clientException);
+
+        $this->loggerMock->expects($this->once())
+            ->method('error')
+            ->with('Credentials validation failed for project 123456: HTTP 401');
+
+        $this->expectException(CredentialsValidationException::class);
+        $this->expectExceptionMessage('401 Unauthorized');
+
+        $this->deliveryApiClient->validateCredentials($credentials);
+    }
+
+    public function testValidateCredentialsThrowsRateLimitExceededException(): void
+    {
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => '6943a905f5a1a5ebd29b4f3c4c15b818',
+        ]);
+
+        $requestMock = $this->createMock(RequestInterface::class);
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->method('getStatusCode')->willReturn(429);
+
+        $clientException = new ClientException('Too Many Requests', $requestMock, $responseMock);
+
+        $this->orderRequestHandlerMock->method('validateCredentials')
+            ->willThrowException($clientException);
+
+        $this->loggerMock->expects($this->once())
+            ->method('error')
+            ->with('Credentials validation failed for project 123456: HTTP 429');
+
+        $this->expectException(RateLimitExceededException::class);
+
+        $this->deliveryApiClient->validateCredentials($credentials);
+    }
+
+    public function testValidateCredentialsThrowsMerchantClientNotFoundException(): void
+    {
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => '6943a905f5a1a5ebd29b4f3c4c15b818',
+        ]);
+
+        $merchantClientException = new MerchantClientNotFoundException();
+
+        $this->orderRequestHandlerMock->method('validateCredentials')
+            ->willThrowException($merchantClientException);
+
+        $this->loggerMock->expects($this->once())
+            ->method('error')
+            ->with('Credentials validation failed for project 123456: Merchant client not found');
+
+        $this->expectException(MerchantClientNotFoundException::class);
+
+        $this->deliveryApiClient->validateCredentials($credentials);
+    }
+
+    public function testValidateCredentialsHandlesMultipleHttpErrorCodes(): void
+    {
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => 'test_password',
+        ]);
+
+        $requestMock = $this->createMock(RequestInterface::class);
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->method('getStatusCode')->willReturn(403);
+        $responseMock->method('getReasonPhrase')->willReturn('Forbidden');
+
+        $clientException = new ClientException('Forbidden', $requestMock, $responseMock);
+
+        $this->orderRequestHandlerMock->method('validateCredentials')
+            ->willThrowException($clientException);
+
+        $this->loggerMock->expects($this->once())
+            ->method('error')
+            ->with('Credentials validation failed for project 123456: HTTP 403');
+
+        $this->expectException(CredentialsValidationException::class);
+        $this->expectExceptionMessage('403 Forbidden');
+
+        $this->deliveryApiClient->validateCredentials($credentials);
     }
 }

--- a/tests/Client/Provider/MerchantClientProviderTest.php
+++ b/tests/Client/Provider/MerchantClientProviderTest.php
@@ -67,6 +67,37 @@ class MerchantClientProviderTest extends TestCase
         $this->assertTrue($options['headers']['Paysera-Test-Mode']);
     }
 
+    public function testReturnsPublicMerchantClientSuccessfully(): void
+    {
+        $provider = new MerchantClientProvider($this->logger);
+        $client = $provider->getPublicMerchantClient();
+
+        $this->assertInstanceOf(MerchantClient::class, $client);
+    }
+
+    public function testPublicMerchantClientHasNoMacAuthentication(): void
+    {
+        $provider = new MerchantClientProvider($this->logger);
+        $client = $provider->getPublicMerchantClient();
+
+        $apiClient = $this->getPrivateProperty($client, 'apiClient');
+        $options = $this->getPrivateProperty($apiClient, 'options');
+
+        $this->assertArrayNotHasKey('mac', $options);
+    }
+
+    public function testPublicMerchantClientHasCorrectUserAgent(): void
+    {
+        $provider = new MerchantClientProvider($this->logger);
+        $client = $provider->getPublicMerchantClient();
+
+        $apiClient = $this->getPrivateProperty($client, 'apiClient');
+        $options = $this->getPrivateProperty($apiClient, 'options');
+
+        $this->assertArrayHasKey('headers', $options);
+        $this->assertSame('Paysera-Delivery-SDK', $options['headers']['User-Agent']);
+    }
+
     private function getPrivateProperty(object $object, string $propertyName)
     {
         $reflection = new ReflectionClass($object);

--- a/tests/DeliveryFacadeTest.php
+++ b/tests/DeliveryFacadeTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Paysera\DeliverySdk\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Paysera\DeliveryApi\MerchantClient\Entity\ProjectCredentials;
 use Paysera\DeliverySdk\DeliveryFacade;
 use Paysera\DeliverySdk\Entity\MerchantOrderInterface;
 use Paysera\DeliverySdk\Entity\PayseraDeliveryOrderRequest;
 use Paysera\DeliverySdk\Service\DeliveryOrderService;
 use Paysera\DeliverySdk\Service\DeliveryOrderCallbackService;
+use Paysera\DeliverySdk\Exception\CredentialsValidationException;
 use Paysera\DeliverySdk\Exception\DeliveryOrderRequestException;
 use Paysera\DeliverySdk\Exception\DeliveryGatewayNotFoundException;
 
@@ -122,5 +124,71 @@ class DeliveryFacadeTest extends TestCase
             ->willThrowException(new DeliveryGatewayNotFoundException('gatewayCode', 'orderNumber'));
 
         $this->deliveryFacade->updateMerchantOrder($deliveryOrderRequest);
+    }
+
+    public function testValidateCredentialsReturnsTrue(): void
+    {
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => '6943a905f5a1a5ebd29b4f3c4c15b818',
+        ]);
+
+        $this->deliveryOrderService
+            ->expects($this->once())
+            ->method('validateCredentials')
+            ->with($this->callback(function ($arg) use ($credentials) {
+                return $arg instanceof ProjectCredentials
+                    && $arg->getProjectId() === $credentials->getProjectId()
+                    && $arg->getPassword() === $credentials->getPassword();
+            }))
+            ->willReturn(true);
+
+        $result = $this->deliveryFacade->validateCredentials($credentials);
+
+        $this->assertTrue($result);
+    }
+
+    public function testValidateCredentialsReturnsFalse(): void
+    {
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => 'invalid_password',
+        ]);
+
+        $this->deliveryOrderService
+            ->expects($this->once())
+            ->method('validateCredentials')
+            ->with($this->callback(function ($arg) use ($credentials) {
+                return $arg instanceof ProjectCredentials
+                    && $arg->getProjectId() === $credentials->getProjectId()
+                    && $arg->getPassword() === $credentials->getPassword();
+            }))
+            ->willReturn(false);
+
+        $result = $this->deliveryFacade->validateCredentials($credentials);
+
+        $this->assertFalse($result);
+    }
+
+    public function testValidateCredentialsThrowsException(): void
+    {
+        $this->expectException(CredentialsValidationException::class);
+
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => '6943a905f5a1a5ebd29b4f3c4c15b818',
+        ]);
+
+        $this->deliveryOrderService
+            ->expects($this->once())
+            ->method('validateCredentials')
+            ->with($this->callback(function ($arg) use ($credentials) {
+                return $arg instanceof ProjectCredentials
+                    && $arg->getProjectId() === $credentials->getProjectId()
+                    && $arg->getPassword() === $credentials->getPassword();
+            }))
+            ->willThrowException(new CredentialsValidationException('401 Unauthorized', null));
+
+        $this->deliveryFacade->validateCredentials($credentials);
     }
 }

--- a/tests/Service/DeliveryOrderServiceTest.php
+++ b/tests/Service/DeliveryOrderServiceTest.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace Paysera\DeliverySdk\Tests\Service;
 
 use Paysera\DeliveryApi\MerchantClient\Entity\Order;
+use Paysera\DeliveryApi\MerchantClient\Entity\ProjectCredentials;
 use Paysera\DeliverySdk\Client\DeliveryApiClient;
 use Paysera\DeliverySdk\Entity\MerchantOrderInterface;
 use Paysera\DeliverySdk\Entity\PayseraDeliveryOrderRequest;
 use Paysera\DeliverySdk\Entity\PayseraDeliverySettingsInterface;
+use Paysera\DeliverySdk\Exception\CredentialsValidationException;
+use Paysera\DeliverySdk\Exception\MerchantClientNotFoundException;
+use Paysera\DeliverySdk\Exception\RateLimitExceededException;
 use Paysera\DeliverySdk\Repository\MerchantOrderRepositoryInterface;
 use Paysera\DeliverySdk\Service\DeliveryLoggerInterface;
 use Paysera\DeliverySdk\Service\DeliveryOrderService;
@@ -117,5 +121,148 @@ class DeliveryOrderServiceTest extends TestCase
         $result = $this->service->prepaidDeliveryOrder($deliveryOrderRequest);
 
         $this->assertSame($order, $result);
+    }
+
+    public function testValidateCredentialsReturnsTrue(): void
+    {
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => '6943a905f5a1a5ebd29b4f3c4c15b818',
+        ]);
+
+        $this->deliveryApiClient->expects($this->once())
+            ->method('validateCredentials')
+            ->with($this->callback(function ($arg) use ($credentials) {
+                return $arg instanceof ProjectCredentials
+                    && $arg->getProjectId() === $credentials->getProjectId()
+                    && $arg->getPassword() === $credentials->getPassword();
+            }))
+            ->willReturn(true);
+
+        $this->logger->expects($this->exactly(2))
+            ->method('info')
+            ->withConsecutive(
+                [$this->stringContains("Attempting to perform operation 'validate_credentials' for project id: 123456")],
+                [$this->stringContains("Operation 'validate_credentials' for project id 123456 completed with result: valid")]
+            );
+
+        $result = $this->service->validateCredentials($credentials);
+
+        $this->assertTrue($result);
+    }
+
+    public function testValidateCredentialsReturnsFalse(): void
+    {
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => 'invalid_password',
+        ]);
+
+        $this->deliveryApiClient->expects($this->once())
+            ->method('validateCredentials')
+            ->with($this->callback(function ($arg) use ($credentials) {
+                return $arg instanceof ProjectCredentials
+                    && $arg->getProjectId() === $credentials->getProjectId()
+                    && $arg->getPassword() === $credentials->getPassword();
+            }))
+            ->willReturn(false);
+
+        $this->logger->expects($this->exactly(2))
+            ->method('info')
+            ->withConsecutive(
+                [$this->stringContains("Attempting to perform operation 'validate_credentials' for project id: 123456")],
+                [$this->stringContains("Operation 'validate_credentials' for project id 123456 completed with result: invalid")]
+            );
+
+        $result = $this->service->validateCredentials($credentials);
+
+        $this->assertFalse($result);
+    }
+
+    public function testValidateCredentialsThrowsRateLimitExceededException(): void
+    {
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => '6943a905f5a1a5ebd29b4f3c4c15b818',
+        ]);
+
+        $exception = new RateLimitExceededException(null);
+
+        $this->deliveryApiClient->expects($this->once())
+            ->method('validateCredentials')
+            ->willThrowException($exception);
+
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with($this->stringContains("Attempting to perform operation 'validate_credentials' for project id: 123456"));
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->stringContains("Operation 'validate_credentials' for project id 123456 failed due to rate limit."),
+                $exception
+            );
+
+        $this->expectException(RateLimitExceededException::class);
+
+        $this->service->validateCredentials($credentials);
+    }
+
+    public function testValidateCredentialsThrowsMerchantClientNotFoundException(): void
+    {
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => '6943a905f5a1a5ebd29b4f3c4c15b818',
+        ]);
+
+        $exception = new MerchantClientNotFoundException();
+
+        $this->deliveryApiClient->expects($this->once())
+            ->method('validateCredentials')
+            ->willThrowException($exception);
+
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with($this->stringContains("Attempting to perform operation 'validate_credentials' for project id: 123456"));
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->stringContains("Operation 'validate_credentials' for project id 123456 failed: merchant client not found."),
+                $exception
+            );
+
+        $this->expectException(MerchantClientNotFoundException::class);
+
+        $this->service->validateCredentials($credentials);
+    }
+
+    public function testValidateCredentialsThrowsCredentialsValidationException(): void
+    {
+        $credentials = new ProjectCredentials([
+            'project_id' => '123456',
+            'password' => 'invalid_password',
+        ]);
+
+        $exception = new CredentialsValidationException('401 Unauthorized', null);
+
+        $this->deliveryApiClient->expects($this->once())
+            ->method('validateCredentials')
+            ->willThrowException($exception);
+
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with($this->stringContains("Attempting to perform operation 'validate_credentials' for project id: 123456"));
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->stringContains("Operation 'validate_credentials' for project id 123456 failed."),
+                $exception
+            );
+
+        $this->expectException(CredentialsValidationException::class);
+
+        $this->service->validateCredentials($credentials);
     }
 }


### PR DESCRIPTION
## What's Changed

  ### New Features
  - ✅ `validateCredentials()` method in `DeliveryFacade` for credential validation
  - ✅ Public `getPublicMerchantClient()` method for unauthenticated requests
  - ✅ New `CredentialsValidationException` exception class for error handling
  - ✅ Rate limiting support (HTTP 429) with proper error handling

  ### Documentation
  - 📚 Comprehensive documentation in `docs/VALIDATING_CREDENTIALS.md`:
    - Usage examples in configuration forms
    - Setup wizard examples
    - Handling different response types (valid/invalid/rate limit)
    - Architectural flow description
    - Best practices and security notes

  ### Technical Implementation

  **Code Changes:**
  - `DeliveryFacade.php` - added entry point `validateCredentials()` method
  - `DeliveryOrderService.php` - business logic with logging
  - `DeliveryApiClient.php` - error handling
  - `DeliveryOrderApiClient.php` - API communication
  - `MerchantClientProvider.php` - new public client without MAC authentication
  - `CredentialsValidationException.php` - new exception class
  - `BaseException.php` - added `E_CREDENTIALS_VALIDATION_FAILED` constant

  **Tests:**
  - ✅ `DeliveryFacadeTest.php` - tests for facade layer
  - ✅ `DeliveryOrderServiceTest.php` - tests for service layer
  - ✅ `DeliveryApiClientTest.php` - tests for api client
  - ✅ `DeliveryOrderApiClientTest.php` - tests for order api client
  - ✅ `MerchantClientProviderTest.php` - tests for public client

  **Dependencies:**
  - Updated `paysera/lib-delivery-api-merchant-client` to `dev-master` with `validateProjectCredentials()` support

  ## How It Works

  The validation uses a public (unauthenticated) API endpoint `/rest/v1/projects/validate-credentials`:
  - **HTTP 204** - credentials are valid
  - **HTTP 401** - credentials are invalid
  - **HTTP 429** - rate limit exceeded

  ## Usage Example

  ```php
  try {
      $isValid = $deliveryFacade->validateCredentials($projectId, $password);

      if ($isValid) {
          // Save credentials and continue
      } else {
          // Show error: invalid credentials
      }
  } catch (CredentialsValidationException $exception) {
      // Handle rate limit or connection errors
  }

  Important Notes

  ⚠️ Purpose: This method is intended only for one-time validation during setup. DO NOT use before regular operations (creating orders, etc.)

  🔒 Security: Validation is performed server-side, without MAC authentication for the public endpoint

  📝 Logging: All validation attempts (successful and failed) are logged via DeliveryLoggerInterface
